### PR TITLE
Implement market integration services

### DIFF
--- a/src/services/marketService.js
+++ b/src/services/marketService.js
@@ -1,0 +1,55 @@
+const API = 'https://simulador-corretora-de-valores.onrender.com/api';
+
+async function request(url, options) {
+  const res = await fetch(url, options);
+  const data = await res.json();
+  if (!res.ok) {
+    throw data;
+  }
+  return data;
+}
+
+export default {
+  async advanceClock(incrementoMinutos) {
+    const token = localStorage.getItem('token');
+    return request(`${API}/market/clock`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token
+      },
+      body: JSON.stringify({ incrementoMinutos })
+    });
+  },
+
+  async addToWatchlist(ticker) {
+    const token = localStorage.getItem('token');
+    return request(`${API}/market/watchlist`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token
+      },
+      body: JSON.stringify({ ticker })
+    });
+  },
+
+  async removeFromWatchlist(ticker) {
+    const token = localStorage.getItem('token');
+    return request(`${API}/market/watchlist/${ticker}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: token
+      }
+    });
+  },
+
+  async getWatchlist() {
+    const token = localStorage.getItem('token');
+    return request(`${API}/market/watchlist`, {
+      headers: {
+        Authorization: token
+      }
+    });
+  }
+};

--- a/src/views/MarketView.vue
+++ b/src/views/MarketView.vue
@@ -9,7 +9,7 @@ export default {
   name: 'MarketView',
   components: { BuyStockModal, AddStockModal, RemoveStockModal, ClockControls },
   props: { stocks: Array, time: String, availableStocks: Array },
-  emits: ['buy-stock', 'add-stock', 'remove-stock'],
+  emits: ['buy-stock', 'add-stock', 'remove-stock', 'advance-time'],
   setup(props, { emit }) {
     const isAddModalVisible = ref(false);
     const selectedStockForBuy = ref(null);
@@ -49,6 +49,10 @@ export default {
       emit('remove-stock', ticker);
     }
 
+    function handleAdvance(minutes) {
+      emit('advance-time', minutes);
+    }
+
     function formatCurrency(value) {
       return value.toLocaleString('pt-BR', {
         style: 'currency',
@@ -70,6 +74,7 @@ export default {
       openRemoveModal,
       handleRemoveModalClose,
       handleRemoveStock,
+      handleAdvance,
     };
   },
 };
@@ -80,7 +85,7 @@ export default {
     <div class="card">
       <div class="card-header d-flex justify-content-between align-items-center">
         <h4 class="mb-0">Cotações do Mercado</h4>
-        <ClockControls :time="time" />
+        <ClockControls :time="time" @advance-time="handleAdvance" />
       </div>
       <div class="card-body">
         <div class="table-responsive">
@@ -95,7 +100,7 @@ export default {
               </tr>
             </thead>
             <tbody>
-              <tr v-for="stock in stocks" :key="stock.id">
+              <tr v-for="stock in stocks" :key="stock.ticker">
                 <td class="fw-bold">{{ stock.ticker }}</td>
                 <td>{{ formatCurrency(stock.price) }}</td>
                 <td :class="stock.variationValue >= 0 ? 'variation-positive' : 'variation-negative'">

--- a/src/views/PortfolioView.vue
+++ b/src/views/PortfolioView.vue
@@ -7,7 +7,7 @@ export default {
   name: 'PortfolioView',
   components: { SellStockModal, ClockControls },
   props: { portfolioItems: Array, time: String },
-  emits: ['sell-stock'],
+  emits: ['sell-stock', 'advance-time'],
   setup(props, { emit }) {
     const selectedItemForSell = ref(null);
 
@@ -22,6 +22,10 @@ export default {
     const handleSell = (payload) => {
       emit('sell-stock', payload);
     };
+
+    function handleAdvance(minutes) {
+      emit('advance-time', minutes);
+    }
 
     function calculateProfitLoss(item) {
       return (item.currentPrice - item.averagePrice) * item.quantity;
@@ -43,6 +47,7 @@ export default {
       calculateProfitLoss,
       totalProfitLoss,
       formatCurrency,
+      handleAdvance,
     };
   },
 };
@@ -53,7 +58,7 @@ export default {
     <div class="card">
       <div class="card-header d-flex justify-content-between align-items-center">
         <h4 class="mb-0">Minha Carteira</h4>
-        <ClockControls :time="time" />
+        <ClockControls :time="time" @advance-time="handleAdvance" />
       </div>
       <div class="card-body">
         <div class="table-responsive">


### PR DESCRIPTION
## Summary
- add `marketService` with calls to watchlist and clock endpoints
- connect MarketView and PortfolioView to emit clock events
- update HomeView to load watchlist from API and handle clock actions

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c5033c6508333ab16cd72df3ad7af