### PR TITLE
Add account service integration

### DIFF
--- a/src/services/accountService.js
+++ b/src/services/accountService.js
@@ -1,0 +1,45 @@
+const API = 'https://simulador-corretora-de-valores.onrender.com/api';
+
+async function request(url, options) {
+  const res = await fetch(url, options);
+  const data = await res.json();
+  if (!res.ok) {
+    throw data;
+  }
+  return data;
+}
+
+export default {
+  async getStatement() {
+    const token = localStorage.getItem('token');
+    return request(`${API}/account/statement`, {
+      headers: {
+        Authorization: token
+      }
+    });
+  },
+
+  async deposit(descricao, valor) {
+    const token = localStorage.getItem('token');
+    return request(`${API}/account/deposit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token
+      },
+      body: JSON.stringify({ descricao, valor })
+    });
+  },
+
+  async withdraw(descricao, valor) {
+    const token = localStorage.getItem('token');
+    return request(`${API}/account/withdraw`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token
+      },
+      body: JSON.stringify({ descricao, valor })
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- implement `accountService` with deposit, withdraw and statement endpoints
- integrate account API in `HomeView`

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c5594904c83339bd2fe6c6194be87