### PR TITLE
Implement buy/sell orders and wallet integration

### DIFF
--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -1,0 +1,74 @@
+const API = 'https://simulador-corretora-de-valores.onrender.com/api';
+
+async function request(url, options) {
+  const res = await fetch(url, options);
+  const data = await res.json();
+  if (!res.ok) {
+    throw data;
+  }
+  return data;
+}
+
+export default {
+  async placeBuyOrder(ticker, quantidade, modo = 'mercado') {
+    const token = localStorage.getItem('token');
+    return request(`${API}/orders/buy`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token,
+      },
+      body: JSON.stringify({ ticker, quantidade, modo }),
+    });
+  },
+
+  async executeBuyOrder(orderId) {
+    const token = localStorage.getItem('token');
+    return request(`${API}/orders/buy/${orderId}/execute`, {
+      method: 'POST',
+      headers: {
+        Authorization: token,
+      },
+    });
+  },
+
+  async listBuyOrders(status = 'todas') {
+    const token = localStorage.getItem('token');
+    return request(`${API}/orders/buy?status=${status}`, {
+      headers: {
+        Authorization: token,
+      },
+    });
+  },
+
+  async placeSellOrder(ticker, quantidade, modo = 'mercado') {
+    const token = localStorage.getItem('token');
+    return request(`${API}/orders/sell`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token,
+      },
+      body: JSON.stringify({ ticker, quantidade, modo }),
+    });
+  },
+
+  async executeSellOrder(orderId) {
+    const token = localStorage.getItem('token');
+    return request(`${API}/orders/sell/${orderId}/execute`, {
+      method: 'POST',
+      headers: {
+        Authorization: token,
+      },
+    });
+  },
+
+  async listSellOrders(status = 'todas') {
+    const token = localStorage.getItem('token');
+    return request(`${API}/orders/sell?status=${status}`, {
+      headers: {
+        Authorization: token,
+      },
+    });
+  },
+};

--- a/src/services/walletService.js
+++ b/src/services/walletService.js
@@ -1,0 +1,21 @@
+const API = 'https://simulador-corretora-de-valores.onrender.com/api';
+
+async function request(url, options) {
+  const res = await fetch(url, options);
+  const data = await res.json();
+  if (!res.ok) {
+    throw data;
+  }
+  return data;
+}
+
+export default {
+  async getWallet() {
+    const token = localStorage.getItem('token');
+    return request(`${API}/wallet`, {
+      headers: {
+        Authorization: token,
+      },
+    });
+  },
+};


### PR DESCRIPTION
## Summary
- add order service for buy/sell API calls
- add wallet service to list portfolio
- integrate new services in Home view

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c5ab34c8c8333b8ae50fa362ad43a