### PR TITLE
Atualiza extrato e carteira após avanço de relógio

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -179,6 +179,8 @@ export default {
         const data = await marketService.advanceClock(minutes);
         simulationTime.value = data.novaHoraNegociacao;
         marketStocks.splice(0, marketStocks.length, ...data.acoes.map(mapStock));
+        await fetchStatement();
+        await fetchWallet();
       } catch (e) {
         console.error(e);
       }


### PR DESCRIPTION
## Summary
- update clock controls to also fetch statement and wallet after clock advance

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c61c859ac8333b427dba27be50267